### PR TITLE
Feat: Adding data source for device type + Fixing typo in model names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ override.tf.json
 # End of https://www.toptal.com/developers/gitignore/api/terraform
 
 dist
+dist/

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -185,7 +185,7 @@ func (client *Client) SendRequest(method string, path string, payload interface{
 		return "", err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -208,6 +208,7 @@ func (client *Client) GetDeviceType(id int) (*models.ResponseDeviceTypes, error)
 	if err != nil {
 		return nil, err
 	}
+
 	var jsonData models.ResponseDeviceTypes
 	err = json.Unmarshal([]byte(resp), &jsonData)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -41,7 +41,7 @@ func AvailablePrefixBody(d *schema.ResourceData) models.AvailablePrefixes {
 }
 
 // GetPrefix will return a prefix
-func (client *Client) GetPrefix(newCidr string) (*models.ReponsePrefix, error) {
+func (client *Client) GetPrefix(newCidr string) (*models.ResponsePrefix, error) {
 	if newCidr == "" {
 		return nil, fmt.Errorf("[ERROR] 'cidr_notation' is empty")
 	}
@@ -52,7 +52,7 @@ func (client *Client) GetPrefix(newCidr string) (*models.ReponsePrefix, error) {
 		return nil, err
 	}
 
-	var jsonData models.ReponsePrefix
+	var jsonData models.ResponsePrefix
 	err = json.Unmarshal([]byte(resp), &jsonData)
 	if err != nil {
 		return nil, err
@@ -200,4 +200,19 @@ func (client *Client) SendRequest(method string, path string, payload interface{
 	}
 
 	return strbody, nil
+}
+
+func (client *Client) GetDeviceType(id int) (*models.ResponseDeviceTypes, error) {
+	path := fmt.Sprintf("%s%d/", models.PathDeviceTypes, id)
+	resp, err := client.SendRequest("GET", path, nil, 200)
+	if err != nil {
+		return nil, err
+	}
+	var jsonData models.ResponseDeviceTypes
+	err = json.Unmarshal([]byte(resp), &jsonData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jsonData, nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -3,6 +3,7 @@ package models
 import "time"
 
 var PathAvailablePrefixes = "/ipam/prefixes/"
+var PathDeviceTypes = "/dcim/device-types/"
 
 type ReponseAvailablePrefixes struct {
 	ID     int `json:"id"`
@@ -98,7 +99,7 @@ type ResponseSites struct {
 	} `json:"results"`
 }
 
-type ReponsePrefix struct {
+type ResponsePrefix struct {
 	Count    int         `json:"count"`
 	Next     interface{} `json:"next"`
 	Previous interface{} `json:"previous"`
@@ -142,4 +143,22 @@ type ReponsePrefix struct {
 		Created     string    `json:"created"`
 		LastUpdated time.Time `json:"last_updated"`
 	} `json:"results"`
+}
+
+type ResponseDeviceTypes struct {
+	ID           int    `json:"id"`
+	DisplayName  string `json:"display"`
+	Manufacturer struct {
+		ID          int    `json:"id"`
+		DisplayName string `json:"display"`
+		Name        string `json:"name"`
+		Slug        string `json:"slug"`
+	} `json:"manufacturer"`
+	Model        string `json:"model"`
+	Slug         string `json:"slug"`
+	PartNumber   string `json:"part_number"`
+	UHeight      int    `json:"u_height"`
+	Descrption   string `json:"description"`
+	CustomFields struct {
+	} `json:"custom_fields"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -154,11 +154,9 @@ type ResponseDeviceTypes struct {
 		Name        string `json:"name"`
 		Slug        string `json:"slug"`
 	} `json:"manufacturer"`
-	Model        string `json:"model"`
-	Slug         string `json:"slug"`
-	PartNumber   string `json:"part_number"`
-	UHeight      int    `json:"u_height"`
-	Descrption   string `json:"description"`
-	CustomFields struct {
-	} `json:"custom_fields"`
+	Model        string      `json:"model"`
+	Slug         string      `json:"slug"`
+	PartNumber   string      `json:"part_number"`
+	Descrption   string      `json:"description"`
+	CustomFields interface{} `json:"custom_fields"`
 }

--- a/provider/data_device_type.go
+++ b/provider/data_device_type.go
@@ -89,7 +89,7 @@ func dataDeviceTypeRead(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*client.Client)
 
 	id := d.Get("id").(int)
-	if id > 0 {
+	if id < 0 {
 		return fmt.Errorf("[ERROR] 'id' cannot be less than 0")
 	}
 

--- a/provider/data_device_type.go
+++ b/provider/data_device_type.go
@@ -1,0 +1,111 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/BESTSELLER/terraform-provider-netbox/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataDeviceType() *schema.Resource {
+	return &schema.Resource{
+		Read: dataDeviceTypeRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "A unique integer value identifying this device type.",
+			},
+			"displayName": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The display name of the device type.",
+			},
+			"manufacturer": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The manufacturer object of the device type.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "A unique integer value identifying this manufacturer.",
+						},
+						"displayName": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The display name of the manufacturer.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the manufacturer name.",
+						},
+						"slug": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The slug of the manufacturer.",
+						},
+					},
+				},
+			},
+			"model": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The model of the device type.",
+			},
+			"slug": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The slug of the device type.",
+			},
+			"partNumber": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The part number of the device type.",
+			},
+			"uHeight": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The height of the device type.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the device type.",
+			},
+			"customFields": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The custom fields of the device type.",
+			},
+		},
+	}
+}
+
+func dataDeviceTypeRead(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*client.Client)
+
+	id := d.Get("id").(int)
+	if id > 0 {
+		return fmt.Errorf("[ERROR] 'id' cannot be less than 0")
+	}
+
+	resp, err := apiClient.GetDeviceType(id)
+	if err != nil {
+		return err
+	}
+
+	d.Set("displayName", resp.DisplayName)
+	d.Set("manufacturer", resp.Manufacturer)
+	d.Set("model", resp.Model)
+	d.Set("slug", resp.Slug)
+	d.Set("partNumber", resp.PartNumber)
+	d.Set("uHeight", resp.UHeight)
+	d.Set("description", resp.Descrption)
+	d.Set("customFields", resp.CustomFields)
+	d.SetId(strconv.Itoa(resp.ID))
+	return nil
+}

--- a/provider/data_device_type.go
+++ b/provider/data_device_type.go
@@ -17,7 +17,7 @@ func dataDeviceType() *schema.Resource {
 				Required:    true,
 				Description: "A unique integer value identifying this device type.",
 			},
-			"displayName": {
+			"displayname": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The display name of the device type.",
@@ -33,7 +33,7 @@ func dataDeviceType() *schema.Resource {
 							Computed:    true,
 							Description: "A unique integer value identifying this manufacturer.",
 						},
-						"displayName": {
+						"displayname": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The display name of the manufacturer.",
@@ -61,12 +61,12 @@ func dataDeviceType() *schema.Resource {
 				Computed:    true,
 				Description: "The slug of the device type.",
 			},
-			"partNumber": {
+			"part_number": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The part number of the device type.",
 			},
-			"uHeight": {
+			"u_height": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The height of the device type.",
@@ -76,7 +76,7 @@ func dataDeviceType() *schema.Resource {
 				Computed:    true,
 				Description: "The description of the device type.",
 			},
-			"customFields": {
+			"custom_fields": {
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Description: "The custom fields of the device type.",
@@ -98,14 +98,14 @@ func dataDeviceTypeRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("displayName", resp.DisplayName)
+	d.Set("displayname", resp.DisplayName)
 	d.Set("manufacturer", resp.Manufacturer)
 	d.Set("model", resp.Model)
 	d.Set("slug", resp.Slug)
-	d.Set("partNumber", resp.PartNumber)
-	d.Set("uHeight", resp.UHeight)
+	d.Set("part_number", resp.PartNumber)
+	d.Set("u_height", resp.UHeight)
 	d.Set("description", resp.Descrption)
-	d.Set("customFields", resp.CustomFields)
+	d.Set("custom_fields", resp.CustomFields)
 	d.SetId(strconv.Itoa(resp.ID))
 	return nil
 }

--- a/provider/data_device_type.go
+++ b/provider/data_device_type.go
@@ -66,11 +66,6 @@ func dataDeviceType() *schema.Resource {
 				Computed:    true,
 				Description: "The part number of the device type.",
 			},
-			"u_height": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The height of the device type.",
-			},
 			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -80,6 +75,11 @@ func dataDeviceType() *schema.Resource {
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Description: "The custom fields of the device type.",
+				Default:     nil,
+				Elem: &schema.Schema{
+					Type:    schema.TypeString,
+					Default: nil,
+				},
 			},
 		},
 	}
@@ -98,14 +98,25 @@ func dataDeviceTypeRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	cf := getCustomFields(resp.CustomFields)
+	if cf != nil {
+		d.Set("custom_fields", cf)
+	}
+
 	d.Set("displayname", resp.DisplayName)
 	d.Set("manufacturer", resp.Manufacturer)
 	d.Set("model", resp.Model)
 	d.Set("slug", resp.Slug)
 	d.Set("part_number", resp.PartNumber)
-	d.Set("u_height", resp.UHeight)
 	d.Set("description", resp.Descrption)
-	d.Set("custom_fields", resp.CustomFields)
 	d.SetId(strconv.Itoa(resp.ID))
 	return nil
+}
+
+func getCustomFields(cf interface{}) map[string]interface{} {
+	cfm, ok := cf.(map[string]interface{})
+	if !ok || len(cfm) == 0 {
+		return nil
+	}
+	return cfm
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -26,8 +26,9 @@ func Provider() terraform.ResourceProvider {
 			"netbox_available_prefix": resourceAvailablePrefixes(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"netbox_prefix": dataPrefix(),
-			"netbox_sites":  dataSites(),
+			"netbox_prefix":      dataPrefix(),
+			"netbox_sites":       dataSites(),
+			"netbox_device_type": dataDeviceType(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/provider/resource_availableprefixes_test.go
+++ b/provider/resource_availableprefixes_test.go
@@ -48,7 +48,7 @@ func testAccCheckRegistryDestroy(s *terraform.State) error {
 
 func testAccCheckAvailablePrefix() string {
 
-	return fmt.Sprintf(`
+	return (`
 
 	data "netbox_prefix" "prefix" {
 		cidr_notation = "172.24.0.0/13"


### PR DESCRIPTION
# Changes
  - Added data source for NetBox device type and includes custom fields.
  - Fixed typos on model names.
  - Fixed deprecated `ioutil` with `io`.
  - Fixed unnecessary use of `fmt.Sprintf`.